### PR TITLE
Fix offline compression

### DIFF
--- a/iogt/processors.py
+++ b/iogt/processors.py
@@ -1,5 +1,8 @@
 from django.conf import settings
 
 
-def env(request):
-    return {'ENV': settings.ENV}
+def compress_settings(request):
+    return {
+        'STATIC_URL': settings.STATIC_URL,
+        'ENV': settings.ENV
+    }

--- a/iogt/processors.py
+++ b/iogt/processors.py
@@ -2,4 +2,4 @@ from django.conf import settings
 
 
 def env(request):
-    return {'ENV': 'dev' if settings.DEBUG else 'prd'}
+    return {'ENV': settings.ENV}

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -129,7 +129,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'molo.core.context_processors.locale',
                 'wagtail.contrib.settings.context_processors.settings',
-                'iogt.processors.env',
+                'iogt.processors.compress_settings',
             ],
         },
     },

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -30,6 +30,8 @@ SECRET_KEY = "llk8#8zc+@9d6m8ln7%azsg)do5^v24rb!0s^^!-t3tn*#r93y"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
+ENV = 'dev'
+
 
 ALLOWED_HOSTS = ['*']
 

--- a/iogt/settings/production.py
+++ b/iogt/settings/production.py
@@ -64,3 +64,10 @@ try:
     from .local import *  # noqa
 except ImportError:
     pass
+
+ENV = 'prd'
+
+COMPRESS_OFFLINE_CONTEXT = {
+    'STATIC_URL': STATIC_URL,
+    'ENV': ENV,
+}

--- a/iogt/settings/production.py
+++ b/iogt/settings/production.py
@@ -5,6 +5,7 @@ from .base import *  # noqa
 
 DEBUG = False
 TEMPLATE_DEBUG = False
+ENV = 'prd'
 
 
 # Compress static files offline
@@ -60,14 +61,14 @@ CAS_ADMIN_PREFIX = '/admin/'
 LOGIN_URL = 'molo.profiles:auth_login'
 CAS_VERSION = '3'
 
-try:
-    from .local import *  # noqa
-except ImportError:
-    pass
-
-ENV = 'prd'
 
 COMPRESS_OFFLINE_CONTEXT = {
     'STATIC_URL': STATIC_URL,
     'ENV': ENV,
 }
+
+
+try:
+    from .local import *  # noqa
+except ImportError:
+    pass

--- a/iogt/templates/base.html
+++ b/iogt/templates/base.html
@@ -2,7 +2,6 @@
 {% load wagtailsettings_tags wagtailimages_tags %}
 {% load google_analytics_tags %}
 {% get_settings %}
-{% get_static_prefix as STATIC_PREFIX %}
 <!DOCTYPE html>
 <html>
     <head>
@@ -31,7 +30,7 @@
         <meta name="msapplication-config" content="/static/favicon/browserconfig.xml">
         <meta name="theme-color" content="#ffffff">
         {% compress css %}
-         <link rel="stylesheet" type="text/css" href="{{ STATIC_PREFIX }}css/{{ ENV }}/style.css">
+         <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/{{ ENV }}/style.css">
         {% endcompress %}
         {% block extra_css %}{% endblock %}
         <script type="text/javascript">
@@ -40,13 +39,13 @@
  
           var operaMiniSingleView = '{% spaceless %} 
             {% compress css %}
-               <link rel="stylesheet" type="text/css" media="handheld" href="{{ STATIC_PREFIX }}css/{{ ENV }}/opera-mini_single-view.css">
+               <link rel="stylesheet" type="text/css" media="handheld" href="{{ STATIC_URL }}css/{{ ENV }}/opera-mini_single-view.css">
             {% endcompress %}
           {% endspaceless %}';
 
           var smartStyles = '{% spaceless %}
              {% compress css %}
-               <link rel="stylesheet" type="text/css" href="{{ STATIC_PREFIX }}css/{{ ENV }}/state_320.css">
+               <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/{{ ENV }}/state_320.css">
              {% endcompress %}
            {% endspaceless %}';
 
@@ -64,7 +63,7 @@
         {% get_current_language as LANGUAGE_CODE %}
         {% if LANGUAGE_CODE|language_bidi == True %}
           {% compress css %}
-            <link rel="stylesheet" type="text/css" href="{{ STATIC_PREFIX }}css/{{ ENV }}/style-rtl.css' %}">
+            <link rel="stylesheet" type="text/css" href="{{ STATIC_URL }}css/{{ ENV }}/style-rtl.css">
           {% endcompress %}
         {% endif %}
         <noscript>Your browser does not support JavaScript!</noscript>


### PR DESCRIPTION
Our recent change to using the assets built with gulp as inputs to django compressor (for cache busting) only work when we aren't doing offline compression, which we use in production.
