### PR TITLE
Redirect users to https when logging in and accessing the admin

### DIFF
--- a/iogt/middleware.py
+++ b/iogt/middleware.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.http import HttpResponsePermanentRedirect
+
+
+class SSLRedirectMiddleware(object):
+    def process_request(self, request):
+        HTTPS_PATHS = getattr(settings, 'HTTPS_PATHS', [])
+        response_should_be_secure = self.response_should_be_secure(
+            request, HTTPS_PATHS)
+        request_is_secure = self.request_is_secure(request)
+        if response_should_be_secure and not request_is_secure:
+            return HttpResponsePermanentRedirect(
+                "https://{}{}".format(request.get_host(),
+                                      request.get_full_path())
+            )
+
+    def response_should_be_secure(self, request, HTTPS_PATHS):
+        for path in HTTPS_PATHS:
+            if request.path.startswith(u'/{}'.format(path)):
+                return True
+        return False
+
+    def request_is_secure(self, request):
+        if 'HTTP_X_FORWARDED_PROTO' in request.META:
+            return request.META['HTTP_X_FORWARDED_PROTO'] == 'https'
+
+        return False

--- a/iogt/middleware.py
+++ b/iogt/middleware.py
@@ -4,9 +4,9 @@ from django.http import HttpResponsePermanentRedirect
 
 class SSLRedirectMiddleware(object):
     def process_request(self, request):
-        HTTPS_PATHS = getattr(settings, 'HTTPS_PATHS', [])
+        https_paths = getattr(settings, 'HTTPS_PATHS', [])
         response_should_be_secure = self.response_should_be_secure(
-            request, HTTPS_PATHS)
+            request, https_paths)
         request_is_secure = self.request_is_secure(request)
         if response_should_be_secure and not request_is_secure:
             return HttpResponsePermanentRedirect(
@@ -14,8 +14,8 @@ class SSLRedirectMiddleware(object):
                                       request.get_full_path())
             )
 
-    def response_should_be_secure(self, request, HTTPS_PATHS):
-        for path in HTTPS_PATHS:
+    def response_should_be_secure(self, request, https_paths):
+        for path in https_paths:
             if request.path.startswith(u'/{}'.format(path)):
                 return True
         return False

--- a/iogt/middleware.py
+++ b/iogt/middleware.py
@@ -1,12 +1,49 @@
+from urlparse import urlparse
+
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
+
+
+def clean_path(path):
+    '''
+    Converts string of URL paths to list of path elements
+    '''
+    if path == u'/':
+        return [u'/']
+    else:
+        return filter(lambda a: a != '', path.split('/'))
+
+
+def clean_paths(paths):
+    '''
+    Converts list of URL paths to list of
+    lists containing only the strings making up the path
+
+    sample input:
+    ['/admin', '/admin/', 'profile/login/']
+
+    sample output:
+    [['admin'], ['admin'], ['profile', 'login']]
+    '''
+    return [clean_path(path) for path in paths]
+
+
+def is_match(path, possible_matches):
+    '''
+    Matches segments of a URL path against a list of possible matches
+    '''
+    for possible_match in possible_matches:
+        if possible_match == path[:len(possible_match)]:
+            return True
+    return False
 
 
 class SSLRedirectMiddleware(object):
     def process_request(self, request):
         https_paths = getattr(settings, 'HTTPS_PATHS', [])
+        clean_https_paths = clean_paths(https_paths)
         response_should_be_secure = self.response_should_be_secure(
-            request, https_paths)
+            request, clean_https_paths)
         request_is_secure = self.request_is_secure(request)
         if response_should_be_secure and not request_is_secure:
             return HttpResponsePermanentRedirect(
@@ -15,10 +52,8 @@ class SSLRedirectMiddleware(object):
             )
 
     def response_should_be_secure(self, request, https_paths):
-        for path in https_paths:
-            if request.path.startswith(u'/{}'.format(path)):
-                return True
-        return False
+        request_path = clean_path(request.path)
+        return is_match(request_path, https_paths)
 
     def request_is_secure(self, request):
         if 'HTTP_X_FORWARDED_PROTO' in request.META:

--- a/iogt/middleware.py
+++ b/iogt/middleware.py
@@ -11,7 +11,8 @@ def clean_path(path):
     if path == u'/':
         return [u'/']
     else:
-        return filter(lambda a: a != '', path.split('/'))
+        return [segment for segment
+                in path.split(u'/') if segment]
 
 
 def clean_paths(paths):

--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -98,6 +98,7 @@ COMMENTS_HIDE_REMOVED = False
 SITE_ID = 1
 
 MIDDLEWARE_CLASSES = [
+    'iogt.middleware.SSLRedirectMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'molo.core.middleware.ForceDefaultLanguageMiddleware',

--- a/iogt/settings/production.py
+++ b/iogt/settings/production.py
@@ -67,6 +67,7 @@ COMPRESS_OFFLINE_CONTEXT = {
     'ENV': ENV,
 }
 
+HTTPS_PATHS = ['admin', 'profiles/register/', 'profiles/login/']
 
 try:
     from .local import *  # noqa

--- a/iogt/tests/test_middleware.py
+++ b/iogt/tests/test_middleware.py
@@ -28,7 +28,7 @@ class TestMiddlewareUtils(TestCase):
         self.assertEqual(clean_path('admin'), ['admin'])
         self.assertEqual(clean_path('admin/login'), ['admin', 'login'])
         self.assertEqual(clean_path('/admin/login/'), ['admin', 'login'])
-        self.assertEqual(clean_path('admin/login'), ['admin', 'login'])
+        self.assertEqual(clean_path('admin/login/'), ['admin', 'login'])
         self.assertEqual(clean_path('/admin/login'), ['admin', 'login'])
         self.assertEqual(clean_path('/admin/login/extra'),
                          ['admin', 'login', 'extra'])

--- a/iogt/tests/test_middleware.py
+++ b/iogt/tests/test_middleware.py
@@ -8,10 +8,68 @@ from django.test import (
 from molo.core.tests.base import MoloTestCaseMixin
 from molo.core.models import Main
 
-from iogt.middleware import SSLRedirectMiddleware
+from iogt.middleware import (
+    SSLRedirectMiddleware,
+    clean_path,
+    clean_paths,
+    is_match,
+)
 
 
 PERMANENT_REDIRECT_STATUS_CODE = 301
+
+
+class TestMiddlewareUtils(TestCase):
+    def test_clean_path(self):
+        self.assertEqual(clean_path(u'/'), [u'/'])
+        self.assertEqual(clean_path('/admin'), ['admin'])
+        self.assertEqual(clean_path('/admin/'), ['admin'])
+        self.assertEqual(clean_path('admin/'), ['admin'])
+        self.assertEqual(clean_path('admin'), ['admin'])
+        self.assertEqual(clean_path('admin/login'), ['admin', 'login'])
+        self.assertEqual(clean_path('/admin/login/'), ['admin', 'login'])
+        self.assertEqual(clean_path('admin/login'), ['admin', 'login'])
+        self.assertEqual(clean_path('/admin/login'), ['admin', 'login'])
+        self.assertEqual(clean_path('/admin/login/extra'),
+                         ['admin', 'login', 'extra'])
+
+    def test_clean_paths(self):
+        self.assertEqual(
+            clean_paths([]), []
+        )
+        self.assertEqual(
+            clean_paths(['/admin', '/admin/', 'admin/', 'admin']),
+            [['admin'], ['admin'], ['admin'], ['admin']]
+        )
+
+    def test_is_match(self):
+        self.assertTrue(
+            is_match(['admin'], [['admin']])
+        )
+        self.assertFalse(
+            is_match(['admin'], [['admin-django']])
+        )
+        self.assertFalse(
+            is_match(['profiles'], [['profiles', 'login']])
+        )
+        self.assertTrue(
+            is_match(['profiles', 'login'], [['profiles', 'login']])
+        )
+        self.assertFalse(
+            is_match(['profiles', 'login'], [['profiles', 'register']])
+        )
+        self.assertTrue(
+            is_match(['profiles', 'login'], [['admin'], ['profiles', 'login']])
+        )
+        self.assertFalse(
+            is_match(['profiles', 'login'], [])
+        )
+        self.assertTrue(
+            is_match(['/'], [['/']])
+        )
+        self.assertTrue(
+            is_match(['/'], [['admin'], ['/']])
+        )
 
 
 @override_settings(HTTPS_PATHS=['admin'])

--- a/iogt/tests/test_middleware.py
+++ b/iogt/tests/test_middleware.py
@@ -1,0 +1,57 @@
+from django.test import (
+    TestCase,
+    Client,
+    RequestFactory,
+    override_settings,
+)
+
+from molo.core.tests.base import MoloTestCaseMixin
+from molo.core.models import Main
+
+from iogt.middleware import SSLRedirectMiddleware
+
+
+PERMANENT_REDIRECT_STATUS_CODE = 301
+
+
+@override_settings(HTTPS_PATHS=['admin'])
+class TestSSLRedirectMiddleware(TestCase, MoloTestCaseMixin):
+    def setUp(self):
+        self.mk_main()
+        self.main = Main.objects.all().first()
+        self.factory = RequestFactory()
+
+    def test_no_redirect_for_home_page(self):
+        request = self.factory.get('/')
+
+        middleware = SSLRedirectMiddleware()
+        response = middleware.process_request(request)
+
+        self.assertEqual(response, None)
+
+    def test_no_redirect_with_https(self):
+        headers = {'HTTP_X_FORWARDED_PROTO': 'https'}
+        request = self.factory.get('/', **headers)
+
+        middleware = SSLRedirectMiddleware()
+        response = middleware.process_request(request)
+
+        self.assertEqual(response, None)
+
+    def test_no_redirect_when_secure(self):
+        headers = {'HTTP_X_FORWARDED_PROTO': 'https'}
+        request = self.factory.get('/admin/', **headers)
+
+        middleware = SSLRedirectMiddleware()
+        response = middleware.process_request(request)
+
+        self.assertEqual(response, None)
+
+    def test_redirect_when_not_secure(self):
+        request = self.factory.get('/admin/')
+
+        middleware = SSLRedirectMiddleware()
+        response = middleware.process_request(request)
+
+        self.assertEqual(response.status_code,
+                         PERMANENT_REDIRECT_STATUS_CODE)


### PR DESCRIPTION
Ticket: https://praekeltorg.atlassian.net/browse/UNICEF-298

This PR will add middleware that will redirect users to use `https` when logging in, registering or accessing the admin.

[Link 1](https://gist.github.com/bryanchow/1035190/c0b060ccee057aa803cfa586d845b2049bb3560a)
[Link 2](https://bitbucket.org/nextscreenlabs/django-ssl-redirect/src/95da4b1eab0ad00a00bcb7b9fb09f02fa8ee7019/ssl_redirect/middleware.py?at=default&fileviewer=file-view-default)
