### PR TITLE
Fixes for new health endpoint

### DIFF
--- a/iogt/settings/base.py
+++ b/iogt/settings/base.py
@@ -533,6 +533,7 @@ GOOGLE_ANALYTICS = {}
 GOOGLE_ANALYTICS_IGNORE_PATH = [
     # health check used by marathon
     '/health/',
+    '/health_iogt/',
     # admin interfaces for wagtail and django
     '/admin/', '/django-admin/',
     # Universal Core content import URL

--- a/iogt/settings/dev.py
+++ b/iogt/settings/dev.py
@@ -7,7 +7,6 @@ DEBUG = True
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 BROKER_URL = 'amqp://rabbit:secret@rabbitmq.com:5672/molo-iogt'
-RABBITMQ_MANAGEMENT_INTERFACE = 'rabbitmq.com:15672'
 
 
 try:

--- a/iogt/templates/robots.txt
+++ b/iogt/templates/robots.txt
@@ -3,3 +3,4 @@ User-agent: *
 Disallow: /admin/
 Disallow: /django-admin/
 Disallow: /health/
+Disallow: /health_iogt/

--- a/iogt/tests/test_views.py
+++ b/iogt/tests/test_views.py
@@ -48,7 +48,6 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
             'molo.commenting:molo-comments-report', args=(comment.pk,)))
         self.assertEqual(response['location'], '/cr/4/1/#c1')
 
-    @override_settings(RABBITMQ_MANAGEMENT_INTERFACE=None)
     def test_health_no_interface_set(self):
         """
         When there is no management interface configured it should not try and
@@ -59,6 +58,7 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @override_settings(RABBITMQ_MANAGEMENT_INTERFACE='rabbitmq.com:15672')
     def test_health_good(self):
         """
         If there is a management interface configured it should check the
@@ -77,6 +77,7 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    @override_settings(RABBITMQ_MANAGEMENT_INTERFACE='rabbitmq.com:15672')
     def test_health_stuck(self):
         """
         If there is a management interface configured it should check the

--- a/iogt/tests/test_views.py
+++ b/iogt/tests/test_views.py
@@ -54,7 +54,7 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
         get the status of the queues
         """
 
-        response = self.client.get(reverse('health_iogt'))
+        response = self.client.get(reverse('health'))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -73,7 +73,7 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
             resp = requests.Response()
             resp.status = status.HTTP_200_OK
             req.return_value = resp, details.encode()
-            response = self.client.get(reverse('health_iogt'))
+            response = self.client.get(reverse('health'))
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -92,7 +92,7 @@ class ViewsTestCase(TestCase, MoloTestCaseMixin):
             resp = requests.Response()
             resp.status = status.HTTP_200_OK
             req.return_value = resp, details.encode()
-            response = self.client.get(reverse('health_iogt'))
+            response = self.client.get(reverse('health'))
 
         self.assertEqual(response.status_code,
                          status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/iogt/urls.py
+++ b/iogt/urls.py
@@ -70,7 +70,7 @@ urlpatterns += patterns(
         template_name='robots.txt', content_type='text/plain')),
     url(r'^sitemap\.xml$', 'wagtail.contrib.wagtailsitemaps.views.sitemap'),
     url(
-        r'^health_iogt/$',
+        r'^health/$',
         views.health_iogt,
         name='health_iogt'
     ),


### PR DESCRIPTION
I made the default for RABBITMQ_MANAGEMENT_INTERFACE None so that it doesn't fail when you run it locally.

I also updated the url because `health_iogt` get redirected.

... and added it to the GA exclude list and robots.txt.